### PR TITLE
[system] accept zero-value for max confidence level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - CI actions validate the generator version
 
 ### Fixed
-- Ignored max confidence level of 0
+- Accept a max confidence level of 0
 
 ## [0.3.0] - 2025-01-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - CI actions validate the generator version
 
+### Fixed
+- Ignored max confidence level of 0
+
 ## [0.3.0] - 2025-01-07
 
 ### Added

--- a/graphql/custom_types.go
+++ b/graphql/custom_types.go
@@ -113,10 +113,6 @@ type ConfidenceLevelInput struct {
 }
 
 func (c ConfidenceLevelInput) MarshalJSON() ([]byte, error) {
-	if reflect.ValueOf(c).IsZero() {
-		return []byte("null"), nil
-	}
-
 	if len(c.Overrides) == 0 {
 		return []byte(fmt.Sprintf(`{"max_confidence":%d, "overrides":[]}`, c.MaxConfidence)), nil
 	}


### PR DESCRIPTION
We should be able to create groups with a max confidence level of 0 even when no Overrides are set.

Fixes #6 