### PR TITLE
[actions] auto-update for new OpenCTI versions

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -1,7 +1,8 @@
 name: opencti-auto-update
 on:
-  schedule:
-    - cron:  "15 2 * * *"
+  pull_request:
+# schedule:
+#   - cron:  "15 2 * * *"
 
 permissions:
   contents: write

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -1,6 +1,7 @@
 name: opencti-auto-update
 on:
-  pull_request:
+  pull_request: # temporary during testing
+    types: [ready_for_review] # temporary during testing
 # schedule:
 #   - cron:  "15 2 * * *"
 
@@ -125,6 +126,7 @@ jobs:
         uses: peter-evans/create-pull-request@v7
         with:
           base: ${{ github.head_ref }} # temporary during testing
+          draft: always-true # temporary during testing
           commit-message: Update GoCTI to $NEXT_VERSION
           branch: feature/release-$NEXT_OPENCTI_VERSION
           title: '[opencti] update to $NEXT_OPENCTI_VERSION'

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -107,7 +107,11 @@ jobs:
         run: |
           pip install ./tools/gocti_type_generator
           source docker-compose.env
-          export GOCTI_REPO=$(echo $GOCTI_REPO) && export OPENCTI_URL=$(echo $OPENCTI_URL) && export OPENCTI_TOKEN=$(echo $OPENCTI_TOKEN) && go generate ./...
+          echo "OPENCTI_TOKEN: $OPENCTI_TOKEN"
+          export GOCTI_REPO
+          export OPENCTI_URL
+          export OPENCTI_TOKEN
+          go generate ./...
 
       - name: Run Go formatters
         run: |

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -125,6 +125,7 @@ jobs:
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v7
         with:
+          token: ${{ secrets.AUTO_UPDATE_OPENCTI }}
           base: ${{ github.head_ref }} # temporary during testing
           draft: always-true # temporary during testing
           commit-message: Update GoCTI to ${{ env.NEXT_VERSION }}

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -127,11 +127,11 @@ jobs:
         with:
           base: ${{ github.head_ref }} # temporary during testing
           draft: always-true # temporary during testing
-          commit-message: Update GoCTI to $NEXT_VERSION
-          branch: feature/release-$NEXT_OPENCTI_VERSION
-          title: '[opencti] update to $NEXT_OPENCTI_VERSION'
+          commit-message: Update GoCTI to ${{ env.NEXT_VERSION }}
+          branch: feature/release-${{ env.NEXT_OPENCTI_VERSION }}
+          title: '[opencti] update to ${{ env.NEXT_OPENCTI_VERSION }}'
           body: |
-            Update GoCTI to support newest OpenCTI version $NEXT_OPENCTI_VERSION
+            Update GoCTI to support newest OpenCTI version ${{ env.NEXT_OPENCTI_VERSION }}
 
             Todo:
             - [ ] Check if there are changes in the [upstream compose](https://github.com/OpenCTI-Platform/docker/blob/master/docker-compose.yml) that need to be applied here

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -1,4 +1,4 @@
-name: Update OpenCTI version
+name: opencti-auto-update
 on:
   schedule:
     - cron:  "15 2 * * *"

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -9,6 +9,10 @@ permissions:
   contents: write
   pull-requests: write
 
+env:
+  GO_VERSION: '1.22.1'
+  GOLANGCI_LINT_VERSION: 'v1.57.2'
+
 jobs:
   opencti-auto-update:
     runs-on: ubuntu-latest
@@ -90,7 +94,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.22.1'
+          go-version: ${{ env.GO_VERSION }}
           cache: true
 
       - uses: actions/setup-python@v5
@@ -112,6 +116,12 @@ jobs:
           export OPENCTI_URL=$(echo $OPENCTI_BASE_URL)
           export OPENCTI_TOKEN=$(echo $OPENCTI_ADMIN_TOKEN)
           go generate ./...
+
+      - name: Run Go linters
+        uses: golangci/golangci-lint-action@v6
+        with:
+          version: ${{ env.GOLANGCI_LINT_VERSION }}
+          args: --fix
 
       - name: Run Go formatters
         run: |

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -128,7 +128,7 @@ jobs:
           base: ${{ github.head_ref }} # temporary during testing
           draft: always-true # temporary during testing
           commit-message: Update GoCTI to ${{ env.NEXT_VERSION }}
-          branch: feature/release-${{ env.NEXT_OPENCTI_VERSION }}
+          branch: feature/release-${{ env.NEXT_VERSION }}
           title: '[opencti] update to ${{ env.NEXT_OPENCTI_VERSION }}'
           body: |
             Update GoCTI to support newest OpenCTI version ${{ env.NEXT_OPENCTI_VERSION }}

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -69,8 +69,9 @@ jobs:
 
       - name: Update changelog
         run: |
+          TODAY=$(date +"%Y-%m-%d")
           CHANGELOG_LINE="- Support OpenCTI version $NEXT_OPENCTI_VERSION"
-          CHANGELOG_HEADER="\#\# \[$NEXT_VERSION\]"
+          CHANGELOG_HEADER="\#\# \[$NEXT_VERSION\] - $TODAY"
 
           UNRELEASED=$(sed -n '/^\#\# \[Unreleased\]/p' ./CHANGELOG.md | head -1)
           if [ -n "$UNRELEASED" ]; then

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -106,7 +106,6 @@ jobs:
       - name: Generate new GoCTI
         run: |
           pip install ./tools/gocti_type_generator
-          source ./docker-compose.env
           echo "OPENCTI_TOKEN: $OPENCTI_ADMIN_TOKEN"
           export GOCTI_REPO=.
           export OPENCTI_URL=$(echo $OPENCTI_BASE_URL)
@@ -116,8 +115,10 @@ jobs:
       - name: Run Go formatters
         run: |
           go install mvdan.cc/gofumpt@latest
+          echo "gofumpt: $(which gofumpt)"
           gofumpt -l -w .
           go install github.com/bombsimon/wsl/v4/cmd/wsl@latest
+          echo "wsl: $(which wsl)"
           wsl --fix ./...
 
       - name: Create Pull Request

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -107,10 +107,7 @@ jobs:
         run: |
           pip install ./tools/gocti_type_generator
           source docker-compose.env
-          export GOCTI_REPO=$(echo $GOCTI_REPO)
-          export OPENCTI_URL=$(echo $OPENCTI_URL)
-          export OPENCTI_TOKEN=$(echo $OPENCTI_TOKEN)
-          go generate ./...
+          export GOCTI_REPO=$(echo $GOCTI_REPO) && export OPENCTI_URL=$(echo $OPENCTI_URL) && export OPENCTI_TOKEN=$(echo $OPENCTI_TOKEN) && go generate ./...
 
       - name: Run Go formatters
         run: |

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -75,9 +75,9 @@ jobs:
 
           UNRELEASED=$(sed -n '/^\#\# \[Unreleased\]/p' ./CHANGELOG.md | head -1)
           if [ -n "$UNRELEASED" ]; then
-            CONTAINS_CHANGED=$(sed -n '/\#\# \[Unreleased\]/,/\#\# \[/p' ./CHANGELOG.md | grep "### Changed")
+            CONTAINS_CHANGED=$(sed -n '/\#\# \[Unreleased\]/,/\#\# \[/p' ./CHANGELOG.md | grep "### Changed" || true)
             if [ -n "$CONTAINS_CHANGED" ]; then
-              sed -in "/\#\# \[Unreleased\]/,/\#\# \[/s/^\#\#\# Changed$/\#\#\# Changed\n$CHANGELOG_LINE/" ./CHANGELOG.md
+              sed -i "/\#\# \[Unreleased\]/,/\#\# \[/s/^\#\#\# Changed$/\#\#\# Changed\n$CHANGELOG_LINE/" ./CHANGELOG.md
             else
               sed -i "s/^\#\# \[Unreleased\]/\#\# \[Unreleased\]\n\n\#\#\# Changed\n$CHANGELOG_LINE/" ./CHANGELOG.md
             fi

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -115,7 +115,7 @@ jobs:
           go install mvdan.cc/gofumpt@latest
           gofumpt -l -w .
           go install github.com/bombsimon/wsl/v4/cmd/wsl@latest
-	        wsl --fix ./...
+          wsl --fix ./...
 
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v7

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -106,11 +106,11 @@ jobs:
       - name: Generate new GoCTI
         run: |
           pip install ./tools/gocti_type_generator
-          source docker-compose.env
-          echo "OPENCTI_TOKEN: $OPENCTI_TOKEN"
-          export GOCTI_REPO
-          export OPENCTI_URL
-          export OPENCTI_TOKEN
+          source ./docker-compose.env
+          echo "OPENCTI_TOKEN: $OPENCTI_ADMIN_TOKEN"
+          export GOCTI_REPO=.
+          export OPENCTI_URL=$(echo $OPENCTI_BASE_URL)
+          export OPENCTI_TOKEN=$(echo $OPENCTI_ADMIN_TOKEN)
           go generate ./...
 
       - name: Run Go formatters

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -8,7 +8,7 @@ permissions:
   pull-requests: write
 
 jobs:
-  update-opencti-version:
+  opencti-auto-update:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -45,7 +45,7 @@ jobs:
             echo "Could not determine latest GoCTI version"
             exit 1
           fi
-          echo "GOCTI_VERSION_VERSION=$GOCTI_VERSION" >> "$GITHUB_ENV"
+          echo "GOCTI_VERSION=$GOCTI_VERSION" >> "$GITHUB_ENV"
           echo "Latest GoCTI version: $GOCTI_VERSION"
 
       - name: Compute next GoCTI version

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -107,7 +107,7 @@ jobs:
       - name: Generate new GoCTI
         run: |
           pip install ./tools/gocti_type_generator
-          echo "OPENCTI_TOKEN: $OPENCTI_ADMIN_TOKEN"
+          source ./docker-compose.env
           export GOCTI_REPO=.
           export OPENCTI_URL=$(echo $OPENCTI_BASE_URL)
           export OPENCTI_TOKEN=$(echo $OPENCTI_ADMIN_TOKEN)

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -70,7 +70,7 @@ jobs:
       - name: Update changelog
         run: |
           CHANGELOG_LINE="- Support OpenCTI version $NEXT_OPENCTI_VERSION"
-          CHANGELOG_HEADER="\#\# \[$NEXT_VERSION\] - $(date +"%Y-%m-%d")"
+          CHANGELOG_HEADER="\#\# \[$NEXT_VERSION\]"
 
           UNRELEASED=$(sed -n '/^\#\# \[Unreleased\]/p' ./CHANGELOG.md | head -1)
           if [ -n "$UNRELEASED" ]; then

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -107,9 +107,9 @@ jobs:
         run: |
           pip install ./tools/gocti_type_generator
           source docker-compose.env
-          export GOCTI_REPO=$(GOCTI_REPO)
-          export OPENCTI_URL=$(OPENCTI_URL)
-          export OPENCTI_TOKEN=$(OPENCTI_TOKEN)
+          export GOCTI_REPO=$(echo $GOCTI_REPO)
+          export OPENCTI_URL=$(echo $OPENCTI_URL)
+          export OPENCTI_TOKEN=$(echo $OPENCTI_TOKEN)
           go generate ./...
 
       - name: Run Go formatters

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -128,6 +128,8 @@ jobs:
           base: ${{ github.head_ref }} # temporary during testing
           draft: always-true # temporary during testing
           commit-message: Update GoCTI to ${{ env.NEXT_VERSION }}
+          committer: weisshorn-cyd-bot <196039234+weisshorn-cyd-bot@users.noreply.github.com>
+          author: weisshorn-cyd-bot <196039234+weisshorn-cyd-bot@users.noreply.github.com>
           branch: feature/release-${{ env.NEXT_VERSION }}
           title: '[opencti] update to ${{ env.NEXT_OPENCTI_VERSION }}'
           body: |

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -117,11 +117,21 @@ jobs:
           export OPENCTI_TOKEN=$(echo $OPENCTI_ADMIN_TOKEN)
           go generate ./...
 
+      - name: Run Go formatters
+        run: |
+          go install mvdan.cc/gofumpt@latest
+          echo "gofumpt: $(which gofumpt)"
+          gofumpt -l -w .
+          go install github.com/bombsimon/wsl/v4/cmd/wsl@latest
+          echo "wsl: $(which wsl)"
+          wsl --fix ./...
+
       - name: Run Go linters
         uses: golangci/golangci-lint-action@v6
         with:
           version: ${{ env.GOLANGCI_LINT_VERSION }}
-          args: --fix
+          working-directory: .
+          args: --config=".golangci.yml" --fix
 
       - name: Run Go formatters
         run: |

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -11,7 +11,7 @@ permissions:
 
 env:
   GO_VERSION: '1.22.1'
-  GOLANGCI_LINT_VERSION: 'v1.57.2'
+  GOLANGCI_LINT_VERSION: 'v1.62.0'
 
 jobs:
   opencti-auto-update:

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -1,0 +1,134 @@
+name: Update OpenCTI version
+on:
+  schedule:
+    - cron:  "15 2 * * *"
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  update-opencti-version:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Get current OpenCTI version
+        run: |
+          OPENCTI_VERSION=$(sed -n 's/.*opencti\/platform:\(.*\)$/\1/p' ./docker-compose.yml | head -1)
+          echo "OPENCTI_VERSION=$OPENCTI_VERSION" >> "$GITHUB_ENV"
+          echo "Current OpenCTI version is $OPENCTI_VERSION"
+
+      - name: Fetch latest OpenCTI version
+        run: |
+          NEXT_OPENCTI_VERSION=$(curl -sL https://api.github.com/repos/OpenCTI-Platform/opencti/releases/latest | jq '.tag_name' | tr -d '"')
+          if [ -z $NEXT_OPENCTI_VERSION ]; then
+            echo "Could not get latest OpenCTI version"
+            exit 1
+          fi
+          echo "NEXT_OPENCTI_VERSION=$NEXT_OPENCTI_VERSION" >> "$GITHUB_ENV"
+          echo "Latest OpenCTI version: $NEXT_OPENCTI_VERSION"
+
+      - name: Test if an update is available
+        run: |
+          if [ "$OPENCTI_VERSION" == "$NEXT_OPENCTI_VERSION" ]; then
+            echo "GoCTI already supports latest OpenCTI version $NEXT_OPENCTI_VERSION"
+            exit 0
+          fi
+          echo "A new OpenCTI version $NEXT_OPENCTI_VERSION is available (GoCTI is currently supporting $OPENCTI_VERSION)"
+
+      - name: Fetch latest GoCTI version
+        run: |
+          GOCTI_VERSION=$(sed -En "s/^\#\# \[(.*)\] \- [0-9]{4}\-[0-9]{2}\-[0-9]{2}$/\1/p" ./CHANGELOG.md | head -1)
+          if [ -z $GOCTI_VERSION ]; then
+            echo "Could not determine latest GoCTI version"
+            exit 1
+          fi
+          echo "GOCTI_VERSION_VERSION=$GOCTI_VERSION" >> "$GITHUB_ENV"
+          echo "Latest GoCTI version: $GOCTI_VERSION"
+
+      - name: Compute next GoCTI version
+        run: |
+          IFS='.' read -ra version_parts <<< "$GOCTI_VERSION"
+          NEXT_VERSION="${version_parts[0]}.$((${version_parts[1]}+1)).${version_parts[2]}"
+          echo "NEXT_VERSION=$NEXT_VERSION" >> "$GITHUB_ENV"
+          echo "Version bump from $GOCTI_VERSION to $NEXT_VERSION"
+
+      - name: Update OpenCTI versions
+        run: |
+          sed -i "s/opencti\/platform\:[0-9]*.[0-9]*.[0-9]*$/\opencti\/platform\:$NEXT_OPENCTI_VERSION/g" ./docker-compose.yml
+          sed -i "s/opencti\/worker\:[0-9]*.[0-9]*.[0-9]*$/\opencti\/worker\:$NEXT_OPENCTI_VERSION/g" ./docker-compose.yml
+          sed -i "s/pycti==[0-9]*.[0-9]*.[0-9]*\",$/\pycti==$NEXT_OPENCTI_VERSION\",/" ./tools/gocti_type_generator/pyproject.toml
+          sed -i "s/OpenCTI version [0-9]*.[0-9]*.[0-9]*.$/\OpenCTI version $NEXT_OPENCTI_VERSION./" ./README.md
+
+      - name: Update GoCTI versions
+        run: |
+          sed -i "s/^version = \"[0-9]*.[0-9]*.[0-9]*\"$/version = \"$NEXT_VERSION\"/" ./tools/gocti_type_generator/pyproject.toml
+          sed -i "s/^\tgoctiVersion = \"[0-9]*.[0-9]*.[0-9]*\"$/\tgoctiVersion = \"$NEXT_VERSION\"/" ./gocti.go
+
+      - name: Update changelog
+        run: |
+          CHANGELOG_LINE="- Support OpenCTI version $NEXT_OPENCTI_VERSION"
+          CHANGELOG_HEADER="\#\# \[$NEXT_VERSION\] - $(date +"%Y-%m-%d")"
+
+          UNRELEASED=$(sed -n '/^\#\# \[Unreleased\]/p' ./CHANGELOG.md | head -1)
+          if [ -n "$UNRELEASED" ]; then
+            CONTAINS_CHANGED=$(sed -n '/\#\# \[Unreleased\]/,/\#\# \[/p' ./CHANGELOG.md | grep "### Changed")
+            if [ -n "$CONTAINS_CHANGED" ]; then
+              sed -in "/\#\# \[Unreleased\]/,/\#\# \[/s/^\#\#\# Changed$/\#\#\# Changed\n$CHANGELOG_LINE/" ./CHANGELOG.md
+            else
+              sed -i "s/^\#\# \[Unreleased\]/\#\# \[Unreleased\]\n\n\#\#\# Changed\n$CHANGELOG_LINE/" ./CHANGELOG.md
+            fi
+
+            sed -i "s/^\#\# \[Unreleased\]/$CHANGELOG_HEADER/" ./CHANGELOG.md
+          else
+            sed -i "8i $CHANGELOG_HEADER\n\n\#\#\# Changed\n$CHANGELOG_LINE\n" ./CHANGELOG.md
+          fi
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.22.1'
+          cache: true
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+          cache: 'pip'
+
+      - name: Start environment
+        run: docker compose --file ./docker-compose.yml --env-file ./docker-compose.env up -d
+
+      - name: Wait on OpenCTI to be reachable
+        run: while [ "$(curl -o /dev/null -s -w %{http_code} localhost:8080)" -ne 200 ]; do echo "waiting..."; sleep 5; done
+
+      - name: Generate new GoCTI
+        run: |
+          pip install ./tools/gocti_type_generator
+          source docker-compose.env
+          export GOCTI_REPO=$(GOCTI_REPO)
+          export OPENCTI_URL=$(OPENCTI_URL)
+          export OPENCTI_TOKEN=$(OPENCTI_TOKEN)
+          go generate ./...
+
+      - name: Run Go formatters
+        run: |
+          go install mvdan.cc/gofumpt@latest
+          gofumpt -l -w .
+          go install github.com/bombsimon/wsl/v4/cmd/wsl@latest
+	        wsl --fix ./...
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v7
+        with:
+          commit-message: Update GoCTI to $NEXT_VERSION
+          branch: feature/release-$NEXT_OPENCTI_VERSION
+          title: '[opencti] update to $NEXT_OPENCTI_VERSION'
+          body: |
+            Update GoCTI to support newest OpenCTI version $NEXT_OPENCTI_VERSION
+
+            Todo:
+            - [ ] Check if there are changes in the [upstream compose](https://github.com/OpenCTI-Platform/docker/blob/master/docker-compose.yml) that need to be applied here
+          labels: release
+
+      - name: Tear down environment
+        run: docker compose --env-file ./docker-compose.env down --volumes --timeout 30

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -124,6 +124,7 @@ jobs:
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v7
         with:
+          base: ${{ github.head_ref }} # temporary during testing
           commit-message: Update GoCTI to $NEXT_VERSION
           branch: feature/release-$NEXT_OPENCTI_VERSION
           title: '[opencti] update to $NEXT_OPENCTI_VERSION'

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -1,9 +1,7 @@
 name: opencti-auto-update
 on:
-  pull_request: # temporary during testing
-    types: [ready_for_review] # temporary during testing
-# schedule:
-#   - cron:  "15 2 * * *"
+  schedule:
+    - cron:  "15 2 * * *"
 
 permissions:
   contents: write
@@ -146,8 +144,6 @@ jobs:
         uses: peter-evans/create-pull-request@v7
         with:
           token: ${{ secrets.AUTO_UPDATE_OPENCTI }}
-          base: ${{ github.head_ref }} # temporary during testing
-          draft: always-true # temporary during testing
           commit-message: Update GoCTI to ${{ env.NEXT_VERSION }}
           committer: weisshorn-cyd-bot <196039234+weisshorn-cyd-bot@users.noreply.github.com>
           author: weisshorn-cyd-bot <196039234+weisshorn-cyd-bot@users.noreply.github.com>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- CI actions workflow to auto-update for new OpenCTI versions
+
 ### Changed
 - Linting exception for long struct tags
 - Regenerate GoCTI
@@ -25,7 +28,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - CI actions validate the generator version
-- CI actions workflow to auto-update for new OpenCTI versions
 
 ### Fixed
 - Accept a max confidence level of 0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - CI actions validate the generator version
+- CI actions workflow to auto-update for new OpenCTI versions
 
 ### Fixed
 - Accept a max confidence level of 0

--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ When updating the supported OpenCTI version:
 - Update the [docker-compose](./docker-compose.yml) file
 - Update the pycti version in [project.toml](./tools/gocti_type_generator/pyproject.toml)
 - Update the [changelog](./CHANGELOG.md) with: `- Support OpenCTI version vX.Y.Z`
+- Update the version in the [readme](./README.md)
 - Regenerate the files through `make generate`
 
 ### Release a new version of GoCTI

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ Each pull request must update the `[Unreleased]` entry in the [changelog](./CHAN
 When updating the supported OpenCTI version:
 - Update the [docker-compose](./docker-compose.yml) file
 - Update the pycti version in [project.toml](./tools/gocti_type_generator/pyproject.toml)
-- Update the [changelog](./CHANGELOG.md) with: `- Support OpenCTI version vX.Y.Z`
+- Update the [changelog](./CHANGELOG.md) with: `- Support OpenCTI version X.Y.Z`
 - Update the version in the [readme](./README.md)
 - Regenerate the files through `make generate`
 


### PR DESCRIPTION
Adds an actions workflow which:
- Pulls for new OpenCTI releases
- If a new release is found, updates the relevant versions
- Runs the GoCTI generator
- Opens a release pull request

Closes #7 