### PR TITLE
[workflows] fix auto-update condition

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -42,7 +42,7 @@ jobs:
         run: |
           if [ "$OPENCTI_VERSION" == "$NEXT_OPENCTI_VERSION" ]; then
             echo "GoCTI already supports latest OpenCTI version $NEXT_OPENCTI_VERSION"
-            echo "update-available=false" >> "$GITHUB_OUTPUT"
+            echo "update-available=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
           echo "A new OpenCTI version $NEXT_OPENCTI_VERSION is available (GoCTI is currently supporting $OPENCTI_VERSION)"

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -1,7 +1,9 @@
 name: opencti-auto-update
 on:
-  schedule:
-    - cron:  "15 2 * * *"
+  # schedule:
+  #   - cron:  "15 2 * * *"
+  pull_request:
+    types: [converted_to_draft]
 
 permissions:
   contents: write

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -1,9 +1,7 @@
 name: opencti-auto-update
 on:
-  # schedule:
-  #   - cron:  "15 2 * * *"
-  pull_request:
-    types: [converted_to_draft]
+  schedule:
+    - cron:  "15 2 * * *"
 
 permissions:
   contents: write
@@ -42,7 +40,7 @@ jobs:
         run: |
           if [ "$OPENCTI_VERSION" == "$NEXT_OPENCTI_VERSION" ]; then
             echo "GoCTI already supports latest OpenCTI version $NEXT_OPENCTI_VERSION"
-            echo "update-available=true" >> "$GITHUB_OUTPUT"
+            echo "update-available=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
           echo "A new OpenCTI version $NEXT_OPENCTI_VERSION is available (GoCTI is currently supporting $OPENCTI_VERSION)"

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -12,8 +12,10 @@ env:
   GOLANGCI_LINT_VERSION: 'v1.62.0'
 
 jobs:
-  opencti-auto-update:
+  look-for-update:
     runs-on: ubuntu-latest
+    outputs:
+      update-available: ${{ steps.test-for-update.outputs.update-available }}
     steps:
       - uses: actions/checkout@v4
 
@@ -34,12 +36,38 @@ jobs:
           echo "Latest OpenCTI version: $NEXT_OPENCTI_VERSION"
 
       - name: Test if an update is available
+        id: test-for-update
         run: |
           if [ "$OPENCTI_VERSION" == "$NEXT_OPENCTI_VERSION" ]; then
             echo "GoCTI already supports latest OpenCTI version $NEXT_OPENCTI_VERSION"
+            echo "update-available=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
           echo "A new OpenCTI version $NEXT_OPENCTI_VERSION is available (GoCTI is currently supporting $OPENCTI_VERSION)"
+          echo "update-available=true" >> "$GITHUB_OUTPUT"
+
+  opencti-auto-update:
+    runs-on: ubuntu-latest
+    needs: look-for-update
+    if: needs.look-for-update.outputs.update-available == 'true'
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Get current OpenCTI version
+        run: |
+          OPENCTI_VERSION=$(sed -n 's/.*opencti\/platform:\(.*\)$/\1/p' ./docker-compose.yml | head -1)
+          echo "OPENCTI_VERSION=$OPENCTI_VERSION" >> "$GITHUB_ENV"
+          echo "Current OpenCTI version is $OPENCTI_VERSION"
+
+      - name: Fetch latest OpenCTI version
+        run: |
+          NEXT_OPENCTI_VERSION=$(curl -sL https://api.github.com/repos/OpenCTI-Platform/opencti/releases/latest | jq '.tag_name' | tr -d '"')
+          if [ -z $NEXT_OPENCTI_VERSION ]; then
+            echo "Could not get latest OpenCTI version"
+            exit 1
+          fi
+          echo "NEXT_OPENCTI_VERSION=$NEXT_OPENCTI_VERSION" >> "$GITHUB_ENV"
+          echo "Latest OpenCTI version: $NEXT_OPENCTI_VERSION"^
 
       - name: Fetch latest GoCTI version
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- Auto-update workflow correctly no longer opens a pull request if OpenCTI is
+  already at the latest version
+
 ## [0.6.0] - 2025-01-24
 
 ### Added


### PR DESCRIPTION
The auto-update workflow does not correctly stop execution if no OpenCTI update is available.
This PR fixes this issue by splitting the workflow in two and adding a condition on the execution of the actual update part.