### PR TITLE
[workflows] fix auto-update branch name

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -175,7 +175,7 @@ jobs:
           commit-message: Update GoCTI to ${{ env.NEXT_VERSION }}
           committer: weisshorn-cyd-bot <196039234+weisshorn-cyd-bot@users.noreply.github.com>
           author: weisshorn-cyd-bot <196039234+weisshorn-cyd-bot@users.noreply.github.com>
-          branch: feature/release-${{ env.NEXT_VERSION }}
+          branch: feature/update-opencti-to-${{ env.NEXT_OPENCTI_VERSION }}
           title: '[opencti] update to ${{ env.NEXT_OPENCTI_VERSION }}'
           body: |
             Update GoCTI to support newest OpenCTI version ${{ env.NEXT_OPENCTI_VERSION }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- Auto-update workflow uses a branch name unique to the OpenCTI version it
+  updates for
+
 ## [0.8.0] - 2025-01-30
 
 ### Changed


### PR DESCRIPTION
Use the next OpenCTI version in the branch name, instead of the next GoCTI version.

Fixes #40 