### PR TITLE
[workflows] Fix PyCTI validation

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -37,8 +37,8 @@ jobs:
       - name: Validate pycti
         run: |
           PYCTI_VERSION=$(sed -n 's/.*pycti==\(.*\)".*/\1/p' tools/gocti_type_generator/pyproject.toml | head -1)
-          if [ "$PYCTI_VERSION" != "$FIRST_VERSION" ]; then
-            echo "pycti is at $PYCTI_VERSION but target OpenCTI is $FIRST_VERSION"
+          if [ "$PYCTI_VERSION" != "$LAST_VERSION" ]; then
+            echo "pycti is at $PYCTI_VERSION but target OpenCTI is $LAST_VERSION"
             exit 1
           fi
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- Validate PyCTI version is last of supported OpenCTI version range
+
 ## [0.28.0] - 2025-05-12
 
 ### Changed


### PR DESCRIPTION
PyCTI version must be validated to be the latest OpenCTI version in the supported range.