### PR TITLE
[workflows] add condition for look-for-graphql-changes

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -48,6 +48,7 @@ jobs:
 
   look-for-graphql-changes:
     runs-on: ubuntu-latest
+    if: needs.look-for-update.outputs.update-available == 'true'
     outputs:
       graphql-changes: ${{ steps.graphql.outputs.graphql-changes }}
     needs: look-for-update

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Validate PyCTI version is last of supported OpenCTI version range
+- Only check for graphql changes if there is a new version of OpenCTI
 
 ## [0.28.0] - 2025-05-12
 


### PR DESCRIPTION
The job `look-for-graphql-changes` needs to be run only if there is an update available for OpenCTI.