### PR TITLE
[workflows] Improve auto-update resilience

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -268,7 +268,7 @@ jobs:
         with:
           version: ${{ env.GOLANGCI_LINT_VERSION }}
           working-directory: .
-          args: --config=".golangci.yml" --fix
+          args: --config=".golangci.yml" --fix --issues-exit-code=0
 
       - name: Run Go formatters
         run: |

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -13,6 +13,7 @@ linters:
     - dupl
     - exhaustruct
     - tagliatelle
+    - funcorder
   settings:
     cyclop:
       max-complexity: 12

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+- Auto-update CI does not error on Go linting failure
+- Disable `funcorder` linter
+
 ## [0.30.0] - 2025-06-25
 
 ### Changed


### PR DESCRIPTION
Improve the resilience of the auto-update procedure in the CI.
- Go linting does not lead to CI failure in auto-update. This allows for manual fixing in the PR.
- Disable `funclen` linter because it does not support auto-fixing and handling this in the generation is not worth the complexity.