### PR TITLE
[go] bump to version 1.25.1

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -14,8 +14,8 @@ permissions:
   contents: read
 
 env:
-  GO_VERSION: '1.24.4'
-  GOLANGCI_LINT_VERSION: 'v2.1.6'
+  GO_VERSION: '1.25.1'
+  GOLANGCI_LINT_VERSION: 'v2.5.0'
 
 jobs:
   golangci-lint:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -12,8 +12,10 @@ linters:
   disable:
     - dupl
     - exhaustruct
-    - tagliatelle
     - funcorder
+    - godoclint
+    - noinlineerr
+    - tagliatelle
   settings:
     cyclop:
       max-complexity: 12

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+- Bump Go to version 1.25.1
+
 ## [0.46.0] - 2025-10-03
 
 ### Changed

--- a/examples/example_list_report_ips_test.go
+++ b/examples/example_list_report_ips_test.go
@@ -25,6 +25,7 @@ import (
 // to retrieve.
 type ExtendedReport struct {
 	entity.Report
+
 	Objects struct {
 		Edges []struct {
 			Node Observable `gocti:"node"`

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/weisshorn-cyd/gocti
 
-go 1.24.4
+go 1.25.1
 
 require (
 	github.com/go-viper/mapstructure/v2 v2.3.0


### PR DESCRIPTION
Upgrade go to 1.25.1 and golangcilint to 2.5